### PR TITLE
chore: extend type declarations for Redis global instances

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,5 +1,9 @@
 import Server from "socket.io";
+import { Redis } from "@upstash/redis";
 
 declare global {
   var io: Server | undefined;
+  var _redis: Redis | undefined;
 }
+
+export {};


### PR DESCRIPTION
- Add dependency Redis
- Updated global variable object var __redis: Redis | undefined

Closes #17 